### PR TITLE
Add the home connection to nmap and ncat...

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,10 +31,10 @@ apps:
         command: nmap
         environment:
             LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas"
-        plugs: [network, network-bind, network-control]
+        plugs: [network, network-bind, network-control, home]
     ncat:
         command: ncat
-        plugs: [network, network-bind, network-control]
+        plugs: [network, network-bind, network-control, home]
     nping:
         command: nping
         plugs: [network, network-bind, network-control]


### PR DESCRIPTION
 to allow file paths within $HOME to be provided as arguments (for e.g. target lists, lua scripts, etc)