### PR TITLE
added content interface slot

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,6 +24,13 @@ license: GPL-2.0
 icon: meta/gui/icon.png
 compression: lzo
 
+slots:
+  nmap:
+    interface: content
+    source:
+      read:
+      - $SNAP/usr
+
 apps:
     nmap:
         command: usr/bin/nmap


### PR DESCRIPTION
I need `nmap` for some of the snaps that I maintain. Adding this `slot` will **not** affect `nmap` in anyway and will allow me to use it in my [spiderfoot snap](https://snapcraft.io/spiderfoot). Once I add this to `spiderfoot`, it'll add a few hundred installs for `nmap`. I'm currently building `nmap` separately for `spiderfoot` which adds to it's **size**.

I also have plans to use this in Metasploit snap once I upgrade it to `core22`. 

Any other developer can also use `nmap` snap in their snaps, by adding this content plug:
```
plugs:
  nmap:
    interface: content
    target: $SNAP
    default-provider: nmap
```
They may have to adjust `target`, if a `usr` folder already exists in their `$SNAP`.

Then they have to adjust their `$LD_LIBRARY_PATH` to match that of your `nmap` snap. I'm using this:-

`$LD_LIBRARY_PATH:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas`

Lastly, they've to add `network-control` interface to able to run `nmap`. 

Thanks.
